### PR TITLE
Add git and docker ignore rules for JetBrains IDEs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,5 @@ dist/
 .github
 examples/
 tests/
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 .fastflows
+
+# JetBrains IDEs
+.idea


### PR DESCRIPTION
This is a very small PR that just adds `.gitignore` and `.dockerignore` rules for files generated by JetBrains IDEs (really Pycharm, in my case)