### PR TITLE
Replace os with pathlib

### DIFF
--- a/fastflows/core/catalog/cache.py
+++ b/fastflows/core/catalog/cache.py
@@ -1,5 +1,5 @@
-import os
 import json
+
 from fastflows.config.app import settings
 
 
@@ -10,13 +10,8 @@ class CatalogCache:
     def __init__(self):
         self.data = self.read()
 
-    def check_or_create_home_folder(self) -> None:
-
-        if not settings.FLOWS_HOME.exists():
-            os.makedirs(settings.FLOWS_HOME, exist_ok=True)
-
     def read(self) -> None:
-        self.check_or_create_home_folder()
+        settings.FLOWS_HOME.mkdir(exist_ok=True, parents=True)
         try:
             with open(settings.CATALOG_CACHE, "r") as f:
                 raw_data = f.read()

--- a/fastflows/core/catalog/reader.py
+++ b/fastflows/core/catalog/reader.py
@@ -1,6 +1,6 @@
 import ast
-import os
 import sys
+from pathlib import Path
 from fastflows.schemas.prefect.flow_data import (
     FlowDataFromFile,
     ScheduleFromFile,
@@ -120,8 +120,8 @@ class FlowFileReader:
                 name=flow_name,
                 entrypoint=f"{self.file_path}:{func_name}",
                 file_path=self.file_path,
-                file_modified=os.path.getmtime(self.file_path)
-                if self.file_path
+                file_modified=Path(self.file_path).stat().st_mtime
+                if self.file_path is not None
                 else None,
                 schedule=Schedule(**schedule.dict(exclude={"lineno"}))
                 if schedule

--- a/fastflows/core/catalog/storage.py
+++ b/fastflows/core/catalog/storage.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 
 class FlowsStorageBase:
@@ -17,12 +17,16 @@ class FlowsStorageBase:
 
 
 class LocalStorage(FlowsStorageBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.storage_path = Path(self.storage_path)
+
     def list(self):
-        if not os.path.isdir(self.storage_path):
+        if not self.storage_path.is_dir():
             raise ValueError(
                 f"Flows Home must be a folder. You provided: {self.storage_path}"
             )
-        return os.listdir(self.storage_path)
+        return list(self.storage_path.iterdir())
 
     def read(self):
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,6 @@ def pytest_configure(config):
 
 
 @pytest.fixture
-def flows_folder() -> str:
+def flows_folder() -> pathlib.Path:
     current_folder = pathlib.Path(__file__).parent
-    return str(current_folder / "test_data" / "flows")
+    return current_folder / "test_data" / "flows"

--- a/tests/unit/test_reader.py
+++ b/tests/unit/test_reader.py
@@ -1,4 +1,3 @@
-import os
 import datetime
 
 import pytest
@@ -9,13 +8,13 @@ pytestmark = pytest.mark.unit
 
 
 def test_extract_tags(flows_folder):
-    file_reader = FlowFileReader(file_path=os.path.join(flows_folder, "simple_flow.py"))
+    file_reader = FlowFileReader(file_path=str(flows_folder / "simple_flow.py"))
     file_reader.file_data = "# tags: data_flow, some_tag"
     assert file_reader._exctract_tags()[0].tags == ["data_flow", "some_tag"]
 
 
 def test_extract_schedule(flows_folder):
-    file_reader = FlowFileReader(file_path=os.path.join(flows_folder, "simple_flow.py"))
+    file_reader = FlowFileReader(file_path=str(flows_folder / "simple_flow.py"))
     file_reader.file_data = (
         "# schedule: interval=3600,anchor_date=2020-01-01T00:00:00Z,timezone=UTC"
     )


### PR DESCRIPTION
This PR replaces path-related usages of the `os` package with `pathlib`, a more current alternative